### PR TITLE
Fix types + cjs/mjs imports

### DIFF
--- a/esbuild.mjs
+++ b/esbuild.mjs
@@ -16,6 +16,8 @@
  */
 
 import esbuild from 'esbuild';
+import { copyFileSync, readdirSync } from 'fs';
+import path from 'path';
 
 await esbuild.build({
 	entryPoints: ['./src/index.ts'],
@@ -44,3 +46,21 @@ await esbuild.build({
 		'.js': '.mjs',
 	},
 });
+
+function copyDeclarationFiles(srcDir) {
+	readdirSync(srcDir, { withFileTypes: true }).forEach((dirent) => {
+		const fullPath = path.join(srcDir, dirent.name);
+
+		if (dirent.isDirectory()) {
+			// Recurse into directories
+			copyDeclarationFiles(fullPath);
+		} else if (dirent.isFile() && path.extname(fullPath) === '.ts') {
+			// Copy .d.ts files to .d.cts
+			const newFileName = path.basename(fullPath, '.d.ts') + '.d.cts';
+			const newFilePath = path.join(srcDir, newFileName);
+			copyFileSync(fullPath, newFilePath);
+		}
+	});
+}
+
+copyDeclarationFiles('./dist');

--- a/package.json
+++ b/package.json
@@ -13,7 +13,7 @@
 						"default": "./dist/index.mjs"
 				},
 				"require": {
-						"types": "./dist/index.d.ts",
+						"types": "./dist/index.d.cts",
 						"default": "./dist/index.cjs"
 				}
 		}

--- a/package.json
+++ b/package.json
@@ -1,8 +1,9 @@
 {
 	"name": "@exact-realty/multipart-parser",
-	"version": "1.0.10",
+	"version": "2.0.0",
 	"description": "TypeScript streaming parser for MIME multipart messages",
 	"main": "dist/index.cjs",
+	"types": "dist/index.d.ts",
 	"type": "module",
 	"module": "./dist/index.mjs",
 	"exports": {
@@ -44,18 +45,18 @@
 	"license": "ISC",
 	"keywords": ["form-data", "formdata", "mime", "mime", "multipart", "multipart/form-data", "multipart/mixed", "multipart/related", "parser", "rfc2046", "rfc2388", "rfc7568"],
 	"devDependencies": {
-		"@types/mocha": "^10.0.4",
-		"@types/node": "^20.9.0",
-		"@typescript-eslint/eslint-plugin": "^6.10.0",
-		"@typescript-eslint/parser": "^6.10.0",
-		"esbuild": "^0.19.5",
-		"eslint": "^8.53.0",
-		"eslint-config-prettier": "^9.0.0",
-		"eslint-plugin-prettier": "^5.0.1",
+		"@types/mocha": "^10.0.6",
+		"@types/node": "^20.10.5",
+		"@typescript-eslint/eslint-plugin": "^6.16.0",
+		"@typescript-eslint/parser": "^6.16.0",
+		"esbuild": "^0.19.10",
+		"eslint": "^8.56.0",
+		"eslint-config-prettier": "^9.1.0",
+		"eslint-plugin-prettier": "^5.1.2",
 		"mocha": "^10.2.0",
 		"nyc": "^15.1.0",
-		"prettier": "^3.0.3",
-		"ts-node": "^10.9.1",
-		"typescript": "^5.2.2"
+		"prettier": "^3.1.1",
+		"ts-node": "^10.9.2",
+		"typescript": "^5.3.3"
 	}
 }

--- a/package.json
+++ b/package.json
@@ -3,7 +3,7 @@
 	"version": "2.0.0",
 	"description": "TypeScript streaming parser for MIME multipart messages",
 	"main": "dist/index.cjs",
-	"types": "dist/index.d.ts",
+	"types": "dist/index.d.cts",
 	"type": "module",
 	"module": "./dist/index.mjs",
 	"exports": {

--- a/src/encodeMultipartMessage.ts
+++ b/src/encodeMultipartMessage.ts
@@ -14,10 +14,10 @@
  */
 
 import { boundaryMatchRegex } from './lib/boundaryRegex.js';
-import createBufferStream from './lib/createBufferStream.js';
+import { createBufferStream } from './lib/createBufferStream.js';
 import type { TTypedArray } from './types/index.js';
 
-type TIterable<T> = AsyncIterable<T> | Iterable<T>;
+export type TIterable<T> = AsyncIterable<T> | Iterable<T>;
 
 export type TDecodedMultipartMessage = {
 	headers: Headers;
@@ -29,13 +29,13 @@ const textEncoder = new TextEncoder();
 
 export const liberalBoundaryMatchRegex = /;\s*boundary=(?:"([^"]+)"|([^;",]+))/;
 
-const multipartBoundaryAlphabet =
+export const multipartBoundaryAlphabet =
 	'ABCDEFGHIJKLMNOPQRSTUVWXYZ' +
 	'abcdefghijklmnopqrstuvwxyz' +
 	'0123456789' +
 	'+_-.';
 
-const generateMultipartBoundary = (): string => {
+export const generateMultipartBoundary = (): string => {
 	const buffer = new Uint8Array(24);
 	globalThis.crypto.getRandomValues(buffer);
 	return Array.from(buffer)
@@ -50,7 +50,7 @@ const pipeToOptions = {
 	preventClose: true,
 };
 
-async function* asyncEncoderGenerator(
+export async function* asyncEncoderGenerator(
 	boundary: string,
 	msg: TIterable<TDecodedMultipartMessage>,
 	ws: WritableStream,
@@ -179,7 +179,7 @@ async function* asyncEncoderGenerator(
 	await createBufferStream(encodedEndBoundary).pipeTo(ws, pipeToOptions);
 }
 
-const encodeMultipartMessage = (
+export const encodeMultipartMessage = (
 	boundary: string,
 	msg: TIterable<TDecodedMultipartMessage>,
 ): ReadableStream<ArrayBuffer> => {
@@ -224,5 +224,3 @@ const encodeMultipartMessage = (
 
 	return readableStream;
 };
-
-export default encodeMultipartMessage;

--- a/src/index.ts
+++ b/src/index.ts
@@ -13,10 +13,23 @@
  * PERFORMANCE OF THIS SOFTWARE.
  */
 
-export { default as encodeMultipartMessage } from './encodeMultipartMessage.js';
-export type { TDecodedMultipartMessage } from './encodeMultipartMessage.js';
+export {
+	encodeMultipartMessage,
+	liberalBoundaryMatchRegex,
+	multipartBoundaryAlphabet,
+	generateMultipartBoundary,
+	asyncEncoderGenerator,
+} from './encodeMultipartMessage.js';
+export type {
+	TDecodedMultipartMessage,
+	TIterable,
+} from './encodeMultipartMessage.js';
 export { boundaryMatchRegex, boundaryRegex } from './lib/boundaryRegex.js';
-export { default as parseMessage } from './parseMessage.js';
+export { parseMessage } from './parseMessage.js';
 export type { TMessage } from './parseMessage.js';
-export * from './parseMultipartMessage.js';
-export { default } from './parseMultipartMessage.js';
+export { parseMultipartMessage } from './parseMultipartMessage.js';
+export type {
+	EState,
+	TMultipartMessage,
+	TMultipartMessageGenerator,
+} from './parseMultipartMessage.js';

--- a/src/lib/createBufferStream.ts
+++ b/src/lib/createBufferStream.ts
@@ -15,7 +15,9 @@
 
 import type { TTypedArray } from '../types/index.js';
 
-const createBufferStream = <T extends TTypedArray | ArrayBuffer>(buffer: T) => {
+export const createBufferStream = <T extends TTypedArray | ArrayBuffer>(
+	buffer: T,
+) => {
 	const readableStream = new ReadableStream<ArrayBuffer>({
 		pull(controller) {
 			if (ArrayBuffer.isView(buffer)) {
@@ -37,5 +39,3 @@ const createBufferStream = <T extends TTypedArray | ArrayBuffer>(buffer: T) => {
 	});
 	return readableStream;
 };
-
-export default createBufferStream;

--- a/src/lib/findIndex.ts
+++ b/src/lib/findIndex.ts
@@ -16,7 +16,10 @@
 import type { TTypedArray } from '../types/index.js';
 
 // Helper function to find the index of a Uint8Array within another Uint8Array
-const findIndex = <T extends TTypedArray>(buffer: T, delimiter: T): number => {
+export const findIndex = <T extends TTypedArray>(
+	buffer: T,
+	delimiter: T,
+): number => {
 	outerLoop: for (let i = 0; i <= buffer.length - delimiter.length; i++) {
 		for (let j = 0; j < delimiter.length; j++) {
 			if (buffer[i + j] !== delimiter[j]) {
@@ -27,5 +30,3 @@ const findIndex = <T extends TTypedArray>(buffer: T, delimiter: T): number => {
 	}
 	return -1;
 };
-
-export default findIndex;

--- a/src/lib/mergeTypedArrays.ts
+++ b/src/lib/mergeTypedArrays.ts
@@ -13,7 +13,7 @@
 
 import type { TTypedArray } from '../types/index.js';
 
-const mergeTypedArrays = <T extends TTypedArray>(
+export const mergeTypedArrays = <T extends TTypedArray>(
 	input0: T,
 	...input: T[]
 ): T => {
@@ -33,5 +33,3 @@ const mergeTypedArrays = <T extends TTypedArray>(
 
 	return mergedArray;
 };
-
-export default mergeTypedArrays;

--- a/src/parseMessage.ts
+++ b/src/parseMessage.ts
@@ -11,7 +11,7 @@
  * PERFORMANCE OF THIS SOFTWARE.
  */
 
-import findIndex from './lib/findIndex.js';
+import { findIndex } from './lib/findIndex.js';
 
 const textDecoder = new TextDecoder();
 const textEncoder = new TextEncoder();
@@ -24,7 +24,7 @@ export type TMessage = {
 	body: Uint8Array | null;
 };
 
-const parseMessage = (buffer: Uint8Array): TMessage => {
+export const parseMessage = (buffer: Uint8Array): TMessage => {
 	let nextIndex = 0;
 
 	const headersArray: [string, string][] = [];
@@ -76,5 +76,3 @@ const parseMessage = (buffer: Uint8Array): TMessage => {
 				: buffer.subarray(nextIndex + newline.length),
 	};
 };
-
-export default parseMessage;

--- a/src/parseMultipartMessage.ts
+++ b/src/parseMultipartMessage.ts
@@ -14,13 +14,13 @@
  */
 
 import { boundaryMatchRegex, boundaryRegex } from './lib/boundaryRegex.js';
-import createBufferStream from './lib/createBufferStream.js';
-import findIndex from './lib/findIndex.js';
-import mergeTypedArrays from './lib/mergeTypedArrays.js';
-import parseMessage from './parseMessage.js';
+import { createBufferStream } from './lib/createBufferStream.js';
+import { findIndex } from './lib/findIndex.js';
+import { mergeTypedArrays } from './lib/mergeTypedArrays.js';
+import { parseMessage } from './parseMessage.js';
 import type { TTypedArray } from './types/index.js';
 
-enum EState {
+export enum EState {
 	PREAMBLE,
 	BODY_PART,
 	ENCAPSULATION,
@@ -39,10 +39,9 @@ export type TMultipartMessage = {
 };
 export type TMultipartMessageGenerator = AsyncGenerator<TMultipartMessage>;
 
-async function* parseMultipartMessage<T extends TTypedArray | ArrayBuffer>(
-	stream: ReadableStream<T>,
-	boundary: string,
-): TMultipartMessageGenerator {
+export async function* parseMultipartMessage<
+	T extends TTypedArray | ArrayBuffer,
+>(stream: ReadableStream<T>, boundary: string): TMultipartMessageGenerator {
 	if (!boundaryRegex.test(boundary)) {
 		throw new Error('Invalid boundary delimiter');
 	}
@@ -227,5 +226,3 @@ async function* parseMultipartMessage<T extends TTypedArray | ArrayBuffer>(
 		reader.releaseLock();
 	}
 }
-
-export default parseMultipartMessage;

--- a/test/encodeMultipartMessage.test.ts
+++ b/test/encodeMultipartMessage.test.ts
@@ -15,10 +15,11 @@
 
 import assert from 'node:assert';
 import { webcrypto } from 'node:crypto';
-import encoder, {
+import {
+	encodeMultipartMessage as encoder,
 	TDecodedMultipartMessage,
 } from '../src/encodeMultipartMessage.js';
-import createBufferStream from '../src/lib/createBufferStream.js';
+import { createBufferStream } from '../src/lib/createBufferStream.js';
 
 !globalThis.crypto &&
 	((() => globalThis || { crypto: {} })().crypto =

--- a/test/parseMultipartMessage.test.ts
+++ b/test/parseMultipartMessage.test.ts
@@ -15,7 +15,8 @@
 
 import assert from 'node:assert/strict';
 import { boundaryMatchRegex } from '../src/lib/boundaryRegex.js';
-import parse, {
+import {
+	parseMultipartMessage as parse,
 	TMultipartMessageGenerator,
 } from '../src/parseMultipartMessage.js';
 


### PR DESCRIPTION
Re: #8

- Removes default exports (https://basarat.gitbook.io/typescript/main-1/defaultisbad)
- Explicit exports (no `export * from './foo.js'`) (I can't find the link right now, but tldr it's bad for ASTs and tree shaking)
- Fixed cjs types (added `types` to package.json)
- Separate mjs and cjs types to `.d.ts` and `.d.cts` so they resolve correctly (ATTW reports no problems now)
- Bumped to 2.0.0 for breaking API change (removing default exports)
