### PR TITLE
Improve multipart boundary parsing and encoding robustness

### DIFF
--- a/.github/workflows/npm-publish.yml
+++ b/.github/workflows/npm-publish.yml
@@ -11,6 +11,7 @@ jobs:
   publish-npm:
     runs-on: ubuntu-latest
     permissions:
+      attestations: write
       contents: read
       id-token: write
     environment: CI

--- a/.github/workflows/pull-request.yml
+++ b/.github/workflows/pull-request.yml
@@ -1,4 +1,6 @@
 name: Run tests before merging
+permissions:
+  contents: read
 
 on:
   pull_request:

--- a/esbuild.ts
+++ b/esbuild.ts
@@ -34,7 +34,7 @@ const buildOptionsBase: esbuild.BuildOptions = {
 	minify: true,
 	entryNames: '[name]',
 	platform: 'node',
-	external: ['esbuild'],
+	external: ['@apeleghq/http-media-type-negotiator'],
 };
 
 const formats: esbuild.Format[] = ['cjs', 'esm'];

--- a/fuzz/src/encodeMultipartMessage.cjs
+++ b/fuzz/src/encodeMultipartMessage.cjs
@@ -30,12 +30,16 @@ async function fuzz(buf) {
 		);
 	const asStr = (b) => b.toString('utf8').replace(/\0/g, '') || 'x';
 	const randomBoundary = () => {
+		if (buf[2] === 0xff) return;
+
 		const a = asStr(slice(0, Math.max(1, buf[0] || 4)));
 		const b = asStr(slice(1, Math.max(1, buf[1] || 4)));
 		return `${a}-${b}-${Math.floor((buf[2] || 1) * 1000)}`;
 	};
 
 	async function* messages() {
+		if (buf[3] === 0xff) return; // no parts
+
 		const count = 1 + ((buf[3] || 0) % 6); // 1..6 messages
 		for (let m = 0; m < count; m++) {
 			const kind = (buf[4 + m] || 0) % 3;
@@ -58,11 +62,35 @@ async function fuzz(buf) {
 				};
 			} else {
 				// parts (single nested part) to keep it tiny
+				const shouldBeBlob = !!((0, Math.random)() > 0.8);
+				const shouldBeReadableStream =
+					!shouldBeBlob && !!((0, Math.random)() > 0.8);
+				const shouldBeInvalid =
+					!shouldBeBlob &&
+					!shouldBeReadableStream &&
+					!!((0, Math.random)() > 0.8);
+
+				const body = slice(40 + m * 8, 16).buffer.slice(0);
 				const sub = {
-					headers: headersTransform([['S', String(m)]]),
-					body: slice(40 + m * 8, 16).buffer.slice(0),
+					headers:
+						buf[0] & 0b10
+							? headersTransform([['S', String(m)]])
+							: undefined,
+					body: shouldBeBlob
+						? new Blob([body])
+						: shouldBeReadableStream
+							? new Response(body).body
+							: shouldBeInvalid
+								? Symbol('invalid-body')
+								: body,
 				};
-				yield { parts: [sub] };
+				yield {
+					headers:
+						buf[0] & 0b01
+							? headersTransform([['T', String(m)]])
+							: undefined,
+					parts: [sub],
+				};
 			}
 		}
 	}

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,13 +1,16 @@
 {
 	"name": "@apeleghq/multipart-parser",
-	"version": "1.0.20",
+	"version": "1.0.21",
 	"lockfileVersion": 3,
 	"requires": true,
 	"packages": {
 		"": {
 			"name": "@apeleghq/multipart-parser",
-			"version": "1.0.20",
+			"version": "1.0.21",
 			"license": "ISC",
+			"dependencies": {
+				"@apeleghq/http-media-type-negotiator": "^1.0.6"
+			},
 			"devDependencies": {
 				"@eslint/eslintrc": "^3.3.1",
 				"@eslint/js": "^9.37.0",
@@ -36,6 +39,12 @@
 			"engines": {
 				"node": ">=0.10.0"
 			}
+		},
+		"node_modules/@apeleghq/http-media-type-negotiator": {
+			"version": "1.0.6",
+			"resolved": "https://registry.npmjs.org/@apeleghq/http-media-type-negotiator/-/http-media-type-negotiator-1.0.6.tgz",
+			"integrity": "sha512-wcEU6eEStiw6hQN4qstp1uo+mPIaXlf/aZHp3+vJVjQvOlEwLCZnzwHj7aBgkrwE3pj2kHIFVF8dX5zJo7IXBg==",
+			"license": "ISC"
 		},
 		"node_modules/@cspotcode/source-map-support": {
 			"version": "0.8.1",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
 	"name": "@apeleghq/multipart-parser",
-	"version": "1.0.20",
+	"version": "1.0.21",
 	"description": "TypeScript streaming parser for MIME multipart messages",
 	"main": "dist/index.cjs",
 	"types": "./dist/index.d.cts",
@@ -101,5 +101,8 @@
 		"prettier": "^3.6.2",
 		"ts-node": "^10.9.2",
 		"typescript": "^5.9.3"
+	},
+	"dependencies": {
+		"@apeleghq/http-media-type-negotiator": "^1.0.6"
 	}
 }

--- a/src/encodeMultipartMessage.ts
+++ b/src/encodeMultipartMessage.ts
@@ -13,7 +13,8 @@
  * PERFORMANCE OF THIS SOFTWARE.
  */
 
-import { boundaryMatchRegex } from './lib/boundaryRegex.js';
+import parseMediaType from '@apeleghq/http-media-type-negotiator/parseMediaType';
+import { boundaryRegex } from './lib/boundaryRegex.js';
 import createBufferStream from './lib/createBufferStream.js';
 import EncodeError from './lib/EncodeError.js';
 
@@ -34,8 +35,6 @@ export type TDecodedMultipartMessage =
 	| TDecodedMultipartMessageWithBody
 	| TDecodedMultipartMessageWithParts;
 
-export const liberalBoundaryMatchRegex = /;\s*boundary=(?:"([^"]+)"|([^;",]+))/;
-
 const isWithParts = (
 	x: TDecodedMultipartMessage,
 ): x is TDecodedMultipartMessageWithParts => {
@@ -46,6 +45,83 @@ const isWithBody = (
 	x: TDecodedMultipartMessage,
 ): x is TDecodedMultipartMessageWithBody => {
 	return (x as TDecodedMultipartMessageWithBody).body != null;
+};
+
+const fixBoundaryParam = (
+	partContentType: string,
+	partBoundaryParam?: [string, string],
+) => {
+	const subBoundary = generateMultipartBoundary();
+	if (!partBoundaryParam) {
+		partContentType = `${partContentType.replace(/;[ \t]*$/, '')}; boundary="${subBoundary}"`;
+	} else {
+		let pos = partContentType.indexOf(';');
+		let lcPartContentType = partContentType.toLowerCase();
+		let alreadyFixed = false;
+
+		for (;;) {
+			const index = lcPartContentType.indexOf('boundary=', pos);
+			if (index === -1) break;
+
+			let boundaryStart = index + 9;
+			const quoted = lcPartContentType[boundaryStart] === '"';
+			if (quoted) {
+				boundaryStart++;
+			}
+
+			if (
+				lcPartContentType.slice(
+					boundaryStart,
+					boundaryStart + partBoundaryParam[1].length,
+				) === partBoundaryParam[1]
+			) {
+				const nextChar =
+					lcPartContentType[
+						boundaryStart + partBoundaryParam[1].length
+					];
+
+				if (
+					(quoted && nextChar === '"') ||
+					(!quoted &&
+						(nextChar === undefined ||
+							nextChar === ';' ||
+							nextChar === ' ' ||
+							nextChar === '\t'))
+				) {
+					// If the fix was already applied, this means that some
+					// ambiguous situation that this logic can't handle has
+					// occurred
+					if (alreadyFixed) {
+						throw new EncodeError(
+							'Invalid boundary given and unable to fix it',
+						);
+					}
+					alreadyFixed = true;
+
+					partContentType =
+						partContentType.slice(0, boundaryStart) +
+						(quoted ? '' : '"') +
+						subBoundary +
+						(quoted ? '' : '"') +
+						partContentType.slice(
+							boundaryStart + partBoundaryParam[1].length,
+						);
+					lcPartContentType =
+						partContentType.slice(0, boundaryStart) +
+						(quoted ? '' : '"') +
+						subBoundary +
+						(quoted ? '' : '"') +
+						lcPartContentType.slice(
+							boundaryStart + partBoundaryParam[1].length,
+						);
+				}
+			}
+
+			pos = boundaryStart;
+		}
+	}
+
+	return [subBoundary, partContentType];
 };
 
 const multipartBoundaryAlphabet =
@@ -97,31 +173,43 @@ async function* asyncEncoderGenerator(
 			if (!partContentType) {
 				subBoundary = generateMultipartBoundary();
 				partContentType = `multipart/mixed; boundary="${subBoundary}"`;
-			} else if (
-				!partContentType.startsWith('multipart/') ||
-				!liberalBoundaryMatchRegex.test(partContentType)
-			) {
-				await ws.abort(
-					new EncodeError(
-						'Invalid multipart content type: ' + partContentType,
-					),
-				);
-				return;
 			} else {
-				const messageBoundaryMatch =
-					partContentType.match(boundaryMatchRegex);
+				const parsedPartContentType = parseMediaType(partContentType);
+				if (
+					!parsedPartContentType[0]
+						.toLowerCase()
+						.startsWith('multipart/')
+				) {
+					await ws.abort(
+						new EncodeError(
+							'Invalid multipart content type: ' +
+								partContentType,
+						),
+					);
+					return;
+				}
+
+				const partBoundaryParam = parsedPartContentType[1].find(
+					(param) => {
+						return param[0].toLowerCase() === 'boundary';
+					},
+				);
 
 				// Invalid boundary. Attempt to replace it.
+				// This logic covers most cases but not some special cases,
+				// such as boundary=orig appearing inside of another parameter
 				if (
-					!messageBoundaryMatch ||
-					!(subBoundary =
-						messageBoundaryMatch[1] || messageBoundaryMatch[2])
+					!partBoundaryParam ||
+					!boundaryRegex.test(partBoundaryParam[1])
 				) {
-					subBoundary = generateMultipartBoundary();
-					partContentType = partContentType.replace(
-						liberalBoundaryMatchRegex,
-						`; boundary="${subBoundary}"`,
+					const fixed = fixBoundaryParam(
+						partContentType,
+						partBoundaryParam,
 					);
+					subBoundary = fixed[0];
+					partContentType = fixed[1];
+				} else {
+					subBoundary = partBoundaryParam[1];
 				}
 			}
 		}
@@ -181,11 +269,7 @@ async function* asyncEncoderGenerator(
 			yield;
 		} else if (isWithParts(part)) {
 			if (!subBoundary) {
-				await ws.abort(
-					new EncodeError(
-						'Runtime exception: undefined part boundary',
-					),
-				);
+				await ws.abort(new EncodeError('Undefined part boundary'));
 				return;
 			}
 
@@ -195,7 +279,7 @@ async function* asyncEncoderGenerator(
 	}
 
 	if (!count) {
-		await ws.abort(Error('At least one part is required'));
+		await ws.abort(new EncodeError('At least one part is required'));
 		return;
 	}
 
@@ -203,6 +287,117 @@ async function* asyncEncoderGenerator(
 	await createBufferStream(encodedEndBoundary).pipeTo(ws, pipeToOptions);
 }
 
+/**
+ * Creates a `ReadableStream` that emits a `multipart/*` message by encoding an
+ * iterable of message parts.
+ *
+ * This function is the inverse of `parseMultipartMessage`. It constructs a
+ * complete multipart message from a series of part objects. It is designed for
+ * efficiency and scalability, processing parts one by one and streaming the
+ * output without buffering the entire message in memory. This makes it ideal
+ * for handling large files or dynamic content.
+ *
+ * The encoder supports various body types for each part, including `ArrayBuffer`,
+ * `ArrayBufferView`, `Blob`, and `ReadableStream`. It also handles nested
+ * multipart messages recursively: if a part contains a `parts` iterable instead
+ * of a `body`, it will be encoded as a nested multipart message with an
+ * automatically generated or corrected boundary.
+ *
+ * @example
+ * ```javascript
+ * async function runExample() {
+ *   const boundary = 'example-boundary';
+
+ *   const parts = [
+ *     {
+ *       headers: new Headers({ 'Content-Type': 'text/plain' }),
+ *       body: new TextEncoder().encode('This is the first part.'),
+ *     },
+ *     {
+ *       headers: new Headers({ 'Content-Type': 'application/json' }),
+ *       body: new TextEncoder().encode(JSON.stringify({
+ *         id: 123,
+ *         status: 'ok'
+ *       })),
+ *     },
+ *     // A nested multipart part
+ *     {
+ *       parts: [
+ *         {
+ *           headers: new Headers({'Content-Type': 'text/plain'}),
+ *           body: new TextEncoder().encode('This is a nested part.'),
+ *         }
+ *       ]
+ *     },
+ *     // Another nested multipart part with a pre-set boundary
+ *     {
+ *       headers: new Headers({
+ *         'Content-Type': 'multipart/example; boundary=foo'
+ *       }),
+ *       parts: [
+ *         {
+ *           headers: new Headers({'Content-Type': 'text/plain'}),
+ *           body: new TextEncoder().encode('This is a nested part.'),
+ *         }
+ *       ]
+ *     }
+ *   ];
+
+ *   // `TransformStream` to convert from ArrayBuffer to `Uint8Array`,
+ *   // as needed by `Response`
+ *   const ABtoU8 = new TransformStream({
+ *     start() {},
+ *     transform(chunk, controller) {
+ *       controller.enqueue(new Uint8Array(chunk));
+ *     },
+ *   });
+ *   encodeMultipartMessage(boundary, parts).pipeThrough(ABtoU8);
+
+ *   // To consume the stream, you can use a Response object
+ *   const response = new Response(ABtoU8.readable);
+ *   const text = await response.text();
+
+ *   console.log(text);
+ * }
+ *
+ * // Expected output will be a string similar to this
+ * // (nested boundary is random):
+ * //
+ * // --example-boundary
+ * // content-type: text/plain
+ * //
+ * // This is the first part.
+ * // --example-boundary
+ * // content-type: application/json
+ * //
+ * // {"id":123,"status":"ok"}
+ * // --example-boundary
+ * // content-type: multipart/mixed; boundary="4_ypcARsDHmD8vEFybz+wVSg"
+ * //
+ * // --4_ypcARsDHmD8vEFybz+wVSg
+ * // content-type: text/plain
+ * //
+ * // This is a nested part.
+ * // --4_ypcARsDHmD8vEFybz+wVSg--
+ * // --example-boundary
+ * // content-type: multipart/example; boundary=foo
+ * //
+ * // --foo
+ * // content-type: text/plain
+ * //
+ * // This is a nested part.
+ * // --foo--
+ * // --example-boundary--
+ * ```
+ *
+ * @param boundary The boundary string used to separate parts. This should be
+ * the raw boundary string, without the leading `--`.
+ * @param msg An iterable (such as an array or an async generator) of message
+ * part objects. Each object represents a part and should contain `headers` and
+ * either a `body` or a nested `parts` iterable.
+ * @returns A `ReadableStream` that yields `ArrayBuffer` chunks of the fully
+ * formed multipart message, ready to be sent in a request or saved to a file.
+ */
 const encodeMultipartMessage = (
 	boundary: string,
 	msg: TIterable<TDecodedMultipartMessage>,

--- a/src/parseMessage.ts
+++ b/src/parseMessage.ts
@@ -24,6 +24,57 @@ export type TMessage = {
 	body: Uint8Array | null;
 };
 
+/**
+ * Parses a single message or message part from a byte buffer into its
+ * constituent headers and body.
+ *
+ * This function processes a `Uint8Array` representing a message, such as a
+ * part from a `multipart/*` payload or a simple email-style message. It reads
+ * headers line-by-line, handling multi-line header values folded with linear
+ * whitespace, until it encounters the empty line (`CRLF`) that separates the
+ * headers from the message body. The remainder of the buffer is returned as the
+ * body.
+ *
+ * If a custom `headersTransform` function is not provided, default headers for
+ * `Content-Type` ('text/plain; charset=us-ascii') and `Content-Transfer-Encoding`
+ * ('7bit') are added if they are not already present in the parsed headers.
+ *
+ * @example
+ * ```javascript
+ * const messageString = [
+ *   'Content-Type: text/plain; charset=utf-8',
+ *   'X-Custom-Header: Some Value',
+ *   '', // Separator line
+ *   'This is the body of the message.',
+ * ].join('\r\n');
+ *
+ * const encoder = new TextEncoder();
+ * const buffer = encoder.encode(messageString);
+ *
+ * const { headers, body } = parseMessage(buffer);
+ *
+ * console.log(headers.get('content-type'));
+ * if (body) {
+ *   console.log(new TextDecoder().decode(body));
+ * }
+ *
+ * // Expected output:
+ * // text/plain; charset=utf-8
+ * // This is the body of the message.
+ * ```
+ *
+ * @param buffer The `Uint8Array` containing the raw message data to be parsed.
+ * @param headersTransform An optional function to process the parsed headers.
+ * It receives an array of header tuples (`[name, value]`) and should return a
+ * standard `Headers` object. If omitted, a `Headers` object is created with
+ * default `Content-Type` and `Content-Transfer-Encoding` if they are missing.
+ * @returns An object containing the parsed `headers` as a `Headers` object
+ * and the `body` as a `Uint8Array`. If the message ends immediately after the
+ * headers, the body will be an empty `Uint8Array`. If the header/body separator
+ * is not found, `body` will be `null`.
+ * @throws {ParseError} Throws if a header line is encountered that does not
+ * contain a colon (`:`) separator.
+ */
 const parseMessage = (
 	buffer: Uint8Array,
 	headersTransform?: (headers: [name: string, value: string][]) => Headers,

--- a/src/parseMultipartMessage.ts
+++ b/src/parseMultipartMessage.ts
@@ -13,7 +13,8 @@
  * PERFORMANCE OF THIS SOFTWARE.
  */
 
-import { boundaryMatchRegex, boundaryRegex } from './lib/boundaryRegex.js';
+import { parseMediaType } from '@apeleghq/http-media-type-negotiator/parseMediaType';
+import { boundaryRegex } from './lib/boundaryRegex.js';
 import createBufferStream from './lib/createBufferStream.js';
 import findIndex from './lib/findIndex.js';
 import isLWSP from './lib/isLWSP.js';
@@ -35,10 +36,93 @@ export type TMultipartMessage = {
 };
 export type TMultipartMessageGenerator = AsyncGenerator<TMultipartMessage>;
 
+/**
+ * Incrementally parses a `multipart/*` message from a readable stream.
+ *
+ * This async generator function reads from the provided stream and yields each
+ * part of the multipart message as it's parsed. It is designed to handle large
+ * messages efficiently by not buffering the entire message in memory.
+ *
+ * The parser can handle nested multipart content. If a part has a `Content-Type`
+ * of `multipart/*`, its `parts` property will be an async generator that can be
+ * consumed to parse the nested message.
+ *
+ * @example
+ * ```javascript
+ * async function runExample() {
+ *   const boundary = 'simple-boundary';
+ *   const multipartMessage = [
+ *     `--${boundary}`,
+ *     'Content-Type: text/plain',
+ *     '',
+ *     'This is the first part.',
+ *     `--${boundary}`,
+ *     'Content-Type: application/json',
+ *     '',
+ *     '{"key": "value"}',
+ *     `--${boundary}--`,
+ *   ].join('\r\n');
+ *
+ *   const stream = new ReadableStream({
+ *     start(controller) {
+ *       controller.enqueue(new TextEncoder().encode(multipartMessage));
+ *       controller.close();
+ *     },
+ *   });
+ *
+ *   try {
+ *     const textDecoder = new TextDecoder();
+ *     for await (const part of parseMultipartMessage(stream, boundary)) {
+ *       console.log('--- New Part ---');
+ *       console.log('Headers:', Object.fromEntries(part.headers.entries()));
+ *       if (part.body) {
+ *         console.log('Body:', textDecoder.decode(part.body));
+ *       }
+ *     }
+ *   } catch (error) {
+ *     console.error('Failed to parse multipart message:', error);
+ *   }
+ * }
+ *
+ * // Expected output:
+ * // --- New Part ---
+ * // Headers: {
+ * //   'content-transfer-encoding': '7bit',
+ * //   'content-type': 'text/plain'
+ * // }
+ * // Body: This is the first part.
+ * // --- New Part ---
+ * // Headers: {
+ * //   'content-transfer-encoding': '7bit',
+ * //   'content-type': 'text/application/json'
+ * // }
+ * // Body: {"key": "value"}
+ * ```
+ *
+ * @generator
+ * @yields An object representing a single part of the multipart message,
+ * containing `headers`, `body`, and an optional `parts` async generator for
+ * nested multipart content.
+ *
+ * @param stream The `ReadableStream` source for the multipart message. The
+ * stream should provide chunks of `ArrayBufferLike` data.
+ * @param boundary The boundary delimiter string that separates the message
+ * parts, as specified in the `Content-Type` header (without the leading `--`).
+ * @param headersTransform An optional function to process or transform the
+ * headers of each parsed part. It receives an array of `[name, value]` string
+ * tuples and should return a `Headers` object.
+ * @param permissive If `true`, the parser will be more lenient when parsing
+ * `Content-Type` headers within the parts. Defaults to `false`.
+ * @returns An async generator (`TMultipartMessageGenerator`) that yields each
+ * parsed message part.
+ * @throws {ParseError} Throws if the multipart message is malformed, such as
+ * having an invalid boundary delimiter or incorrect part separation.
+ */
 async function* parseMultipartMessage(
 	stream: ReadableStream<ArrayBufferLike>,
 	boundary: string,
 	headersTransform?: (headers: [name: string, value: string][]) => Headers,
+	permissive?: boolean,
 ): TMultipartMessageGenerator {
 	if (!boundaryRegex.test(boundary)) {
 		throw new ParseError('Invalid boundary delimiter');
@@ -171,24 +255,33 @@ async function* parseMultipartMessage(
 								headersTransform,
 							);
 
-							const partContentType =
-								parsedPart.headers.get('content-type');
-
 							let innerParts:
 								| TMultipartMessage['parts']
 								| undefined = undefined;
 
+							const partContentType =
+								parsedPart.headers.get('content-type');
+
+							const parsedPartContentType = partContentType
+								? parseMediaType(partContentType, permissive)
+								: null;
+
 							if (
 								parsedPart.body &&
-								partContentType?.startsWith('multipart/')
+								parsedPartContentType?.[0]
+									.toLowerCase()
+									.startsWith('multipart/')
 							) {
-								const partBoundaryMatch =
-									partContentType.match(boundaryMatchRegex);
+								const partBoundaryParam =
+									parsedPartContentType[1].find((param) => {
+										return (
+											param[0].toLowerCase() ===
+											'boundary'
+										);
+									});
 
-								if (partBoundaryMatch) {
-									const partBoundary =
-										partBoundaryMatch[1] ||
-										partBoundaryMatch[2];
+								if (partBoundaryParam) {
+									const partBoundary = partBoundaryParam[1];
 
 									innerParts = parseMultipartMessage(
 										createBufferStream(parsedPart.body),

--- a/tsconfig.json
+++ b/tsconfig.json
@@ -1,8 +1,8 @@
 {
 	"compilerOptions": {
 		"target": "es2020",
-		"module": "esnext",
-		"moduleResolution": "node",
+		"module": "NodeNext",
+		"moduleResolution": "NodeNext",
 		"outDir": "dist",
 		"strict": true,
 		"strictNullChecks": true,
@@ -18,6 +18,10 @@
 		"typeRoots": ["./node_modules/@types", "./@types"]
 	},
 	"ts-node": {
+		"compilerOptions": {
+			"module": "ESNext",
+			"moduleResolution": "bundler"
+		},
 		"experimentalResolver": true
 	},
 	"include": ["src/**/*", "@types/*.d.ts"],


### PR DESCRIPTION
This commit overhauls the handling of `Content-Type` headers and boundaries for both parsing and encoding multipart messages.

- Replaces fragile regex-based boundary extraction with the more robust `@apeleghq/http-media-type-negotiator` library. This properly handles various `Content-Type` header formats as defined by the RFC.
- The encoder can now more intelligently fix or generate valid boundaries for nested multipart parts that have invalid or missing `boundary` parameters.
- Fuzz testing for the encoder has been significantly expanded to cover more body types (`Blob`, `ReadableStream`) and edge cases.
- Adds comprehensive JSDoc and examples to all major public functions.

Additionally, this updates the project's build and CI systems by:
- Modernising the TypeScript configuration to use `NodeNext`.
- Adjusting GitHub token permissions.